### PR TITLE
Update version number in woo button template override

### DIFF
--- a/woocommerce/single-product/add-to-cart/simple.php
+++ b/woocommerce/single-product/add-to-cart/simple.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 7.0.1
+ * @version 10.2.0
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
Solves the message about an outdated WooCommerce template.

Only bumped version number because the change introduced in WooCommerce 10.2.0 for this template is related only to block themes.

See #185