### PR TITLE
Fix Google Fonts URL formatting

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -255,7 +255,7 @@ function sydney_scripts() {
 	$is_amp = sydney_is_amp();
 
 	if ( null !== sydney_google_fonts_url() ) {
-		wp_enqueue_style( 'sydney-google-fonts', esc_url( sydney_google_fonts_url() ), array(), '20250902' );
+		wp_enqueue_style( 'sydney-google-fonts', sydney_google_fonts_url(), array(), '20250902' );
 	}
 
 	wp_enqueue_style( 'sydney-ie9', get_template_directory_uri() . '/css/ie9.css', array( 'sydney-style' ), '20250902' );

--- a/inc/editor.php
+++ b/inc/editor.php
@@ -7,7 +7,7 @@
 function sydney_editor_styles() {
 	wp_enqueue_style( 'sydney-block-editor-styles', get_theme_file_uri( '/sydney-gutenberg-editor-styles.css' ), '', '20220208', 'all' );
 
-	wp_enqueue_style( 'sydney-fonts', esc_url( sydney_google_fonts_url() ), array(), '20250901' );
+	wp_enqueue_style( 'sydney-fonts', sydney_google_fonts_url(), array(), '20250901' );
 
 
 	//Dynamic styles


### PR DESCRIPTION
Removes double escaping that is not needed in order to stop the Google Fonts url from breaking.

See #195